### PR TITLE
Added support for different file encodings

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -2,6 +2,7 @@ var _ = require('lazy.js');
 var rc = require('rc');
 var fs = require('fs');
 var path = require('path');
+var iconv = require('iconv-lite');
 
 var Slap = require('./ui/Slap');
 var util = require('./util');
@@ -38,8 +39,15 @@ if (opts.h || opts.help) {
   return process.exit(0);
 }
 
+// Check if encoding is supported
+if(!iconv.encodingExists(opts.editor.encoding)){
+  // Failback to utf-8
+  opts.editor.encoding = 'utf8';
+}
 logger(opts.logger);
 highlightClient.send(_(opts.logger).merge({type: 'logger'}).toObject());
+// Add additional file encodings
+iconv.extendNodeEncodings();
 var slap = new Slap(opts);
 
 var homeRc = Slap.normalizePath('~/.' + package.name + 'rc');

--- a/lib/ui/Header.js
+++ b/lib/ui/Header.js
@@ -92,7 +92,7 @@ Header.prototype.render = function () {
   }
   self.leftContent.setContent('\u270b ' + markupPath);
 
-  var right = [(cursor.y+1)+','+(cursor.x+1) + ' ('+editor.lines().length+')'];
+  var right = [(cursor.y+1)+','+(cursor.x+1) + ' ('+editor.lines().length+')' + ' ' + editor.options.encoding];
   if (!self.parent.insertMode()) right.unshift(markup('OVR', style.overwrite));
   var message = self.message();
   if (message) {

--- a/lib/ui/Slap.js
+++ b/lib/ui/Slap.js
@@ -78,7 +78,7 @@ Slap.prototype.path = util.getterSetter('path', null, Slap.normalizePath);
 Slap.prototype.open = function (givenPath) {
   var self = this;
   givenPath = Slap.normalizePath(givenPath);
-  return fs.readFileAsync(givenPath)
+  return fs.readFileAsync(givenPath, {encoding:self.editor.options.encoding})
     .then(function (data) {
       self.path(givenPath);
       self.editor.text(data, path.extname(givenPath).slice(1));
@@ -102,9 +102,8 @@ Slap.prototype.save = function (givenPath) {
   var self = this;
   givenPath = givenPath ? Slap.normalizePath(givenPath) : self.path();
   if (!givenPath) return;
-
   var text = self.editor.text();
-  return fs.writeFileAsync(givenPath, text, {flags: 'w'})
+  return fs.writeFileAsync(givenPath, text, {encoding:self.editor.options.encoding, flags: 'w'})
     .then(function () {
       self.editor.changeStack.save();
       self.emit('save', givenPath, text);

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "copy-paste": "slap-editor/node-copy-paste",
     "entities": "^1.1.1",
     "highlight.js": "slap-editor/highlight.js#slap",
+    "iconv-lite": "^0.4.4",
     "lazy.js": "^0.3.2",
     "lex": "^1.7.5",
     "lodash": "^2.4.1",

--- a/slap.ini
+++ b/slap.ini
@@ -1,6 +1,7 @@
 ; This is the default slap configuration, which you can override in ~/.slaprc.
 
 [editor]
+encoding = utf8
 useSpaces = true
 tabSize = 2
 pageLines = 10


### PR DESCRIPTION
The title says it all.
- Added iconv-lite
- New ini setting editor.encoding
- Failback to utf-8
- UI Header shows active encoding
