### PR TITLE
'friendlier' default color scheme

### DIFF
--- a/slap.ini
+++ b/slap.ini
@@ -170,8 +170,13 @@ focusPrev[] = "left"
 ;;;;;;;;;;
 ; Styles ;
 ;;;;;;;;;;
+
+; Available colors:
+; black, red, green, yellow, blue, magenta, cyan, white
+; lightblack, lightred, lightgreen, lightyellow, lightblue, lightmagenta, lightcyan, lightwhite
+
 [header.style]
-bg = "magenta"
+bg = "lightblack"
 changed = "{yellow-fg}{bold}"
 info = "{blue-bg}{white-fg}"
 success = "{green-bg}{white-fg}"
@@ -181,11 +186,11 @@ blinkStyle = "{inverse}"
 overwrite = "{red-bg}{white-fg}"
 
 [form.style]
-bg = "magenta"
+bg = "lightblack"
 bold = true
 
 [dialog.style]
-bg = "magenta"
+bg = "lightblack"
 
 [editor.style]
 selection = "{cyan-bg}"
@@ -224,8 +229,8 @@ symbol = ""
 constant = ""
 
 [editor.gutter.style]
-bg = "magenta"
-currentLine = "{white-bg}{magenta-fg}{bold}"
+bg = "lightblack"
+currentLine = "{white-bg}{black-fg}{bold}"
 
 [fileBrowser]
 selectedBg = "blue"


### PR DESCRIPTION
I replaced the default `magenta` with a more neutral `lightblack` - see #72 