### PR TITLE
Simple fix for #120

### DIFF
--- a/lib/ui/Editor.js
+++ b/lib/ui/Editor.js
@@ -77,7 +77,7 @@ Editor.prototype.open = Promise.method(function (path) {
   path = util.resolvePath(path);
   return chardet.detectFileAsync(path) // return Promise.resolve(chardet.detectFileSync(path))
     .then(function (encoding) { self.textBuf.setEncoding(encoding); })
-    .then(self.ready) // ensures textBuf path-changed is triggered in _initHandlers
+    .then(function () { self.ready; }) // ensures textBuf path-changed is triggered in _initHandlers
     .then(function () { return self.textBuf.setPath(path); })
     .then(function () { return self.textBuf.load(); })
     .then(function () { self.selection.setHeadPosition(new Point(0, 0)); })


### PR DESCRIPTION
Avoids raising a warning by placing `self.ready` in a function, fixing #120.