### PR TITLE
Fix install on Arch Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,7 @@ is_executable () {
 
 alias errcho='>&2 echo'
 npm_needs_sudo=''
+needs_python_env='false'
 
 echo "# Installing slap..."
 
@@ -27,6 +28,7 @@ if ! (is_executable npm && is_executable node && is_executable git); then
     emerge nodejs git
   elif is_executable pacman; then
     pacman -S nodejs npm git
+    needs_python_env='true'
   else
     errcho "Couldn't determine OS. Please install NodeJS manually, then run this script again."
     errcho "Visit https://github.com/joyent/node/wiki/installing-node.js-via-package-manager for instructions on how to install NodeJS on your OS."
@@ -35,7 +37,15 @@ if ! (is_executable npm && is_executable node && is_executable git); then
 fi
 
 if [ -z $npm_needs_sudo ]; then
-  sudo npm install -g slap
+  if [ -z $needs_python_env ]; then
+    sudo PYTHON=python2 npm install -g slap
+  else
+    sudo npm install -g slap
+  fi
 else
-  npm install -g slap
+  if [ -z $needs_python_env ]; then
+    PYTHON=python2 npm install -g slap
+  else
+    npm install -g slap
+  fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ is_executable () {
 
 alias errcho='>&2 echo'
 npm_needs_sudo=''
-needs_python_env='false'
+needs_python_env=''
 
 echo "# Installing slap..."
 
@@ -37,13 +37,13 @@ if ! (is_executable npm && is_executable node && is_executable git); then
 fi
 
 if [ -z "$npm_needs_sudo" ]; then
-  if [ -n '$needs_python_env' ]; then
+  if [ -n "$needs_python_env" ]; then
     sudo PYTHON=python2 npm install -g slap
   else
     sudo npm install -g slap
   fi
 else
-  if [ -n '$needs_python_env' ]; then
+  if [ -n "$needs_python_env" ]; then
     PYTHON=python2 npm install -g slap
   else
     npm install -g slap

--- a/install.sh
+++ b/install.sh
@@ -36,14 +36,14 @@ if ! (is_executable npm && is_executable node && is_executable git); then
   fi
 fi
 
-if [ -z $npm_needs_sudo ]; then
-  if [ -z $needs_python_env ]; then
+if [ -z "$npm_needs_sudo" ]; then
+  if [ -n '$needs_python_env' ]; then
     sudo PYTHON=python2 npm install -g slap
   else
     sudo npm install -g slap
   fi
 else
-  if [ -z $needs_python_env ]; then
+  if [ -n '$needs_python_env' ]; then
     PYTHON=python2 npm install -g slap
   else
     npm install -g slap

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ if ! (is_executable npm && is_executable node && is_executable git); then
   elif is_executable emerge; then
     emerge nodejs git
   elif is_executable pacman; then
-    pacman -S nodejs git
+    pacman -S nodejs npm git
   else
     errcho "Couldn't determine OS. Please install NodeJS manually, then run this script again."
     errcho "Visit https://github.com/joyent/node/wiki/installing-node.js-via-package-manager for instructions on how to install NodeJS on your OS."


### PR DESCRIPTION
Arch linux has removed npm from the nodejs package:

> Notice: npm is not shipped with nodejs since 0.12.2-4

Arch Linux also uses python 3.4 by default, node-gyp requires Python 2 to function. So when installing on Arch we have to use the python2 executable.