### PR TITLE
Fix: limited text-buffer versions to 6.1.x to maintain compatibility with njs>12 && iojs

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node-clap": "^0.0.5",
     "rc": "^1.0.0",
     "slap-clipboard-plugin": "^0.0.10",
-    "text-buffer": "^6.1.3",
+    "text-buffer": "~6.1.3",
     "traverse": "^0.6.6",
     "update-notifier": "^0.5.0",
     "winston": "^1.0.0",


### PR DESCRIPTION
Regarding issue https://github.com/slap-editor/slap/issues/164 .

Issue: Selection does not update until user writes something (arrow keys / mouse cursor do not cause selection update).

Reason: `text-buffer` does not cooperate after version `6.1.3`. This fix reverts the dependency on `text-buffer` back to the `6.1.x` and restores interactions for all node versions + iojs.