### PR TITLE
Basic blue color scheme

### DIFF
--- a/slap.ini
+++ b/slap.ini
@@ -63,7 +63,7 @@ hide = "escape"
 ; (light)white
 
 [header.style]
-bg = "magenta"
+bg = "blue"
 changed = "{yellow-fg}{bold}"
 info = "{blue-bg}{white-fg}"
 success = "{green-bg}{white-fg}"
@@ -76,7 +76,7 @@ overwrite = "{red-bg}{white-fg}"
 blink = true
 
 [form.style]
-bg = "magenta"
+bg = "green"
 bold = true
 
 [dialog.style]


### PR DESCRIPTION
Changed:
- header style background to "blue" from "magenta"
- form style background to "green" from "magenta"

[Gutter background color PR](https://github.com/slap-editor/editor-widget/pull/1)

More details here #8 and preview [here](https://github.com/slap-editor/slap/issues/8#issuecomment-125796769)