### PR TITLE
Updated base-widget to version 1.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "base-widget": "1.0.5",
+    "base-widget": "1.0.7",
     "blessed": "0.1.81",
     "bluebird": "2.10.2",
     "editor-widget": "1.0.12",


### PR DESCRIPTION
:rocket:

base-widget just published version 1.0.7, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 9 commits (ahead by 9, behind by 0).

- [3da0188](https://github.com/slap-editor/base-widget/commit/3da0188bb947ff7d4fb7d571c236971533a202b4): 1.0.7
- [8ab57a7](https://github.com/slap-editor/base-widget/commit/8ab57a7745c6ae352579572989f78a3ac7adae11): Merge pull request #3 from slap-editor/node-4
- [337867f](https://github.com/slap-editor/base-widget/commit/337867fe554c6462c5962d0168dbc0a86c7f7896): fix(node4): temporarily pin text-buffer to slap-editor/text-buffer#06fa9ed
- [e43a79d](https://github.com/slap-editor/base-widget/commit/e43a79d3a27ec0b8f3545edd4662e10505b9246e): Merge pull request #2 from slap-editor/greenkeeper-rc-1.1.2
- [714d12d](https://github.com/slap-editor/base-widget/commit/714d12d445a4a80a205013fb8010dbfda40b8d19): chore(package): update rc to version 1.1.2
- [238a96f](https://github.com/slap-editor/base-widget/commit/238a96f95a4bd1cbec7c03632a4c93ad1b596a3b): Merge pull request #1 from slap-editor/greenkeeper-pin
- [d35158d](https://github.com/slap-editor/base-widget/commit/d35158df78212caa6f73747a6e9b55f8e5878a78): chore(package): pin dependencies
- [7fd0b80](https://github.com/slap-editor/base-widget/commit/7fd0b80e1efedda7bb3e15ca3e7b0b5798b87aa0): 1.0.6
- [9171697](https://github.com/slap-editor/base-widget/commit/9171697f28e885fb0b443923df596becdbad08f5): chore(deps): slap-util@1.0.5

See the [full diff](https://github.com/slap-editor/base-widget/compare/58d536bf691ca89c74a44d2ac0be32aa97eb9cdb...3da0188bb947ff7d4fb7d571c236971533a202b4).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>