### PR TITLE
Updated editor-widget to version 1.0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "base-widget": "1.0.7",
     "blessed": "0.1.81",
     "bluebird": "2.10.2",
-    "editor-widget": "1.0.12",
+    "editor-widget": "1.0.14",
     "lodash": "3.10.1",
     "mkdirp": "0.5.1",
     "node-clap": "0.0.5",


### PR DESCRIPTION
:rocket:

editor-widget just published version 1.0.14, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 19 commits (ahead by 19, behind by 0).

- [67d42cd](https://github.com/slap-editor/editor-widget/commit/67d42cd240653e2bed33bc2a715af9e8b43df260): 1.0.14
- [0a88f94](https://github.com/slap-editor/editor-widget/commit/0a88f949c2e6257283e1d10922537e0de41abe2d): Merge pull request #8 from slap-editor/greenkeeper-base-widget-1.0.7
- [ebff4ef](https://github.com/slap-editor/editor-widget/commit/ebff4ef6c844318c8a527ccb9cbeed172c2d6b90): Merge branch 'master' into greenkeeper-base-widget-1.0.7
- [cb5889b](https://github.com/slap-editor/editor-widget/commit/cb5889ba0c2f7fd18c1b34ec4556b1515f1eb713): chore(package): update base-widget to version 1.0.7
- [6755ec7](https://github.com/slap-editor/editor-widget/commit/6755ec7ad10509ac805057cb5951114a19d78eb2): 1.0.13
- [5716b04](https://github.com/slap-editor/editor-widget/commit/5716b04cac380fd5a6cf6134b75df66caf54bcb5): Merge pull request #7 from slap-editor/node-4
- [8585f9e](https://github.com/slap-editor/editor-widget/commit/8585f9e09cd7bcadd641b3f9abde9769e0a9027a): fix(node4): temporarily pin text-buffer to slap-editor/text-buffer#06fa9ed
- [e781043](https://github.com/slap-editor/editor-widget/commit/e7810436d0cb51d96c152418b32361e19789fbfc): Merge pull request #5 from slap-editor/greenkeeper-tape-4.2.1
- [0441e09](https://github.com/slap-editor/editor-widget/commit/0441e09ed64cb2d94d3f3d179635ca58876f8803): Merge branch 'master' into greenkeeper-tape-4.2.1
- [d6cb7da](https://github.com/slap-editor/editor-widget/commit/d6cb7da5b06a39dbba6646b67d48f70c8bc2f9c5): Merge pull request #6 from slap-editor/greenkeeper-es6-set-0.1.2
- [38d2fc9](https://github.com/slap-editor/editor-widget/commit/38d2fc99965fac205acf678bc7095c326d1590b9): chore(package): update es6-set to version 0.1.2
- [6299706](https://github.com/slap-editor/editor-widget/commit/62997061dffe278e83c5dad673d5fc0b9d294576): chore(package): update tape to version 4.2.1
- [9cdf6ad](https://github.com/slap-editor/editor-widget/commit/9cdf6ade7cae1616990e55452c9001f26886db1a): Merge pull request #4 from slap-editor/greenkeeper-iconv-lite-0.4.13
- [0e2e3e0](https://github.com/slap-editor/editor-widget/commit/0e2e3e01a022a20df575378c5735f6ca15d2258b): chore(package): update iconv-lite to version 0.4.13
- [ac6d2a4](https://github.com/slap-editor/editor-widget/commit/ac6d2a4be70e19c8400ec2ba0bf356acfca85c66): Merge pull request #3 from slap-editor/greenkeeper-rc-1.1.2


There are 19 commits in total. See the [full diff](https://github.com/slap-editor/editor-widget/compare/5697cd218d709ef6cdff5d1824ca0c62fc267914...67d42cd240653e2bed33bc2a715af9e8b43df260).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>