### PR TITLE
fix(editor): Added support for pipes

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,6 +3,7 @@ var path = require('path');
 var rc = require('rc');
 
 var util = require('slap-util');
+var ttys = require('ttys');
 var package = require('../package');
 var baseDir = path.join(__dirname, '..');
 var configFile = path.join(baseDir, package.name + '.ini');
@@ -60,11 +61,15 @@ if (opts.perf.profile && process.execArgv.indexOf('--prof') === -1) {
 
 function readAsync (stream) {
   return new Promise(function (resolve, reject) {
-    var chunks = [];
-    stream
-      .on('error', reject)
-      .on('data', chunks.push.bind(chunks))
-      .on('end', function () { resolve(Buffer.concat(chunks)); });
+    if(!stream.isTTY) { // Checks if there is a pipe
+      var chunks = [];
+      stream
+        .on('error', reject)
+        .on('data', chunks.push.bind(chunks))
+        .on('end', function () { resolve(Buffer.concat(chunks)); });      
+    }else{
+      resolve();
+    }
   });
 }
 
@@ -83,8 +88,8 @@ module.exports = function (options) {
   ]).spread(function (userDir, stdin) {
     if (userDir) opts = _.merge({logger: {file: path.resolve(userDir, package.name+'.log')}}, opts);
     opts = _.merge({editor: {logger: opts.logger}}, opts);
+    opts.screenOpts.input = ttys.stdin; // Uses ttys to read from /dev/tty
     util.logger(opts.logger);
-
     util.logger.info("loading...");
     util.logger.verbose("configuration:", opts);
 
@@ -95,13 +100,12 @@ module.exports = function (options) {
     Promise.all(opts._.map(function (path, i) {
       return slap.open(path.toString(), !i);
     })).done();
-
-    if (stdin) {
-      var pane = new Pane({parent: self});
-      pane.editor.textBuf.setText(stdin.toString());
+    
+    if (!opts._.length) { // if no files are passed
+      var pane = new Pane({parent: slap});
+      // Sets stdin from pipe if it exists
+      if (stdin) pane.editor.textBuf.setText(stdin.toString());
       pane.setCurrent();
-    } else if (!opts._.length) { // if no files are passed
-      new Pane({parent: slap}).setCurrent(); // open a new empty file
       if (!opts.config) { // first run without a file passed
         slap.help().done();
         fs.createReadStream(path.join(__dirname, '..', 'default-config.ini')).pipe(fs.createWriteStream(path.join(userDir, 'config')));

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -58,6 +58,16 @@ if (opts.perf.profile && process.execArgv.indexOf('--prof') === -1) {
   return;
 }
 
+function readAsync (stream) {
+  return new Promise(function (resolve, reject) {
+    var chunks = [];
+    stream
+      .on('error', reject)
+      .on('data', chunks.push.bind(chunks))
+      .on('end', function () { resolve(Buffer.concat(chunks)); });
+  });
+}
+
 var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require('fs'));
 
@@ -67,7 +77,10 @@ var Pane = require('./ui/Pane');
 
 module.exports = function (options) {
   opts = _.merge(opts, options);
-  return Slap.getUserDir().catch(Promise.resolve()).then(function (userDir) {
+  return Promise.all([
+    Slap.getUserDir().catch(Promise.resolve()),
+    readAsync(process.stdin)
+  ]).spread(function (userDir, stdin) {
     if (userDir) opts = _.merge({logger: {file: path.resolve(userDir, package.name+'.log')}}, opts);
     opts = _.merge({editor: {logger: opts.logger}}, opts);
     util.logger(opts.logger);
@@ -83,7 +96,11 @@ module.exports = function (options) {
       return slap.open(path.toString(), !i);
     })).done();
 
-    if (!opts._.length) { // if no files are passed
+    if (stdin) {
+      var pane = new Pane({parent: self});
+      pane.editor.textBuf.setText(stdin.toString());
+      pane.setCurrent();
+    } else if (!opts._.length) { // if no files are passed
       new Pane({parent: slap}).setCurrent(); // open a new empty file
       if (!opts.config) { // first run without a file passed
         slap.open(path.join(baseDir, 'README.md'), true)

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "node-clap": "0.0.5",
     "rc": "1.1.5",
     "slap-util": "1.0.5",
+    "ttys": "0.0.3",
     "update-notifier": "0.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Builds off of 59216ca to implement accepting input from the unix pipe (eg. `netstat | slap`). 

Currently, the editor only supports pipe input if there are no arguments (by choice to mimic behavior of running `netstat | less some_file.txt`).

Fixes #193 