### PR TITLE
On startup, focus on editor

### DIFF
--- a/lib/ui/EditorPane.js
+++ b/lib/ui/EditorPane.js
@@ -31,6 +31,12 @@ function EditorPane (opts) {
   self.saveAsForm = new SaveAsForm({parent: self});
   self.saveAsCloseForm = new SaveAsCloseForm({parent: self});
 }
+EditorPane.prototype.setCurrent = function () {
+  var self = this;
+  Pane.prototype.setCurrent.apply(self, arguments);
+  self.editor.focus();
+  return self;
+};
 
 EditorPane.prototype.getTitle = function () {
   var self = this;


### PR DESCRIPTION
Currently, when starting slap with no arguments, the editor pane is not focussed, which means that it is either impossible (or at best unintuitive) to start writing a new file. This commit fixes that.