### PR TITLE
Submitting the goLine form should not add a newline

### DIFF
--- a/lib/ui/BaseFindForm.js
+++ b/lib/ui/BaseFindForm.js
@@ -59,13 +59,6 @@ BaseFindForm.prototype._initHandlers = function () {
   });
 
   textBuf.onDidChange(function () { self.find(textBuf.getText()); });
-  self.findField.on('keypress', function (ch, key) {
-    var text = textBuf.getText();
-    switch (self.resolveBinding(key)) {
-      case 'next': self.find(text, 1); return false;
-      case 'prev': self.find(text, -1); return false;
-    };
-  });
 
   return BaseForm.prototype._initHandlers.apply(self, arguments);
 };

--- a/lib/ui/FindForm.js
+++ b/lib/ui/FindForm.js
@@ -96,6 +96,15 @@ FindForm.prototype._initHandlers = function () {
     }
     editor._updateContent();
   }, self.options.perf.findThrottle));
+
+  self.findField.on('keypress', function (ch, key) {
+    var text = self.findField.textBuf.getText();
+    switch (self.resolveBinding(key)) {
+      case 'next': self.find(text, 1); return false;
+      case 'prev': self.find(text, -1); return false;
+    };
+  });
+
   return BaseFindForm.prototype._initHandlers.apply(self, arguments);
 };
 

--- a/lib/ui/GoLineForm.js
+++ b/lib/ui/GoLineForm.js
@@ -30,6 +30,18 @@ GoLineForm.prototype.__proto__ = BaseFindForm.prototype;
 
 GoLineForm.prototype._initHandlers = function () {
   var self = this;
+
+  self.findField.on('keypress', function (ch, key) {
+    var lineNumber = self.findField.textBuf.getText();
+    switch (self.resolveBinding(key)) {
+      // Use setTimeout as a horrible hack to prevent
+      // the keypress from being transferred to the editor,
+      // causing an unintentional extra linebreak.
+      case 'next':   setTimeout(function(){ self.find(lineNumber, 1) }, 1); return false;
+      case 'submit': setTimeout(function(){ self.find(lineNumber, 1) }, 1); return false;
+    };
+  });
+
   self.on('cancel', function () { self.resetEditor(); });
   self.on('show', function () { self.findField.textBuf.setText(''); });
   self.on('find', function (lineNumber, direction) {


### PR DESCRIPTION
Moved next and prev to findForm, where multiple results are possible.
Prevented the enter keypress event from being transferred to the editor.