### PR TITLE
Refactor out label class

### DIFF
--- a/lib/ui/FindForm.js
+++ b/lib/ui/FindForm.js
@@ -6,6 +6,7 @@ var util = require('slap-util');
 var BaseWidget = require('base-widget');
 var Slap = require('./Slap');
 var BaseFindForm = require('./BaseFindForm');
+var Label = require('./Label');
 
 FindForm._label = " find (/.*/ for regex): ";
 FindForm._regExpRegExp = /^\/(.+)\/(\w*)$/i;
@@ -19,15 +20,13 @@ function FindForm (opts) {
     findField: {left: FindForm._label.length}
   }, Slap.global.options.form.find, opts));
 
-  self.findLabel = new BaseWidget(_.merge({
+  self.findLabel = new Label(_.merge({
     parent: self,
     tags: true,
     content: FindForm._label,
     top: 0,
-    height: 1,
     left: 0,
     width: FindForm._label.length,
-    style: self.options.style
   }, self.options.findLabel));
 }
 FindForm.prototype.__proto__ = BaseFindForm.prototype;

--- a/lib/ui/GoLineForm.js
+++ b/lib/ui/GoLineForm.js
@@ -4,6 +4,7 @@ var BaseWidget = require('base-widget');
 
 var Slap = require('./Slap');
 var BaseFindForm = require('./BaseFindForm');
+var Label = require('./Label');
 
 GoLineForm._label = " line number: ";
 function GoLineForm (opts) {
@@ -15,15 +16,13 @@ function GoLineForm (opts) {
     findField: {left: GoLineForm._label.length}
   }, Slap.global.options.form.goLine, opts));
 
-  self.goLineLabel = new BaseWidget(_.merge({
+  self.goLineLabel = new Label(_.merge({
     parent: self,
     tags: true,
     content: GoLineForm._label,
     top: 0,
-    height: 1,
     left: 0,
     width: GoLineForm._label.length,
-    style: self.options.style
   }, self.options.goLineLabel));
 }
 GoLineForm.prototype.__proto__ = BaseFindForm.prototype;

--- a/lib/ui/Label.js
+++ b/lib/ui/Label.js
@@ -1,0 +1,24 @@
+var blessed = require('blessed');
+var _ = require('lodash');
+
+var util = require('slap-util');
+
+var BaseWidget = require('base-widget');
+var Slap = require('./Slap');
+
+function Label (opts) {
+  var self = this;
+
+  if (!(self instanceof Label)) return new Label(opts);
+
+  opts = _.merge({
+    height: 1
+  }, Slap.global.options.label, opts);
+
+  BaseWidget.blessed.Text.call(self, opts);
+  BaseWidget.call(self, opts);
+}
+
+Label.prototype.__proto__ = BaseWidget.blessed.Text.prototype;
+
+module.exports = Label;

--- a/lib/ui/SaveAsForm.js
+++ b/lib/ui/SaveAsForm.js
@@ -4,6 +4,7 @@ var BaseWidget = require('base-widget');
 var Field = require('editor-widget').Field;
 var Slap = require('./Slap');
 var BaseForm = require('./BaseForm');
+var Label = require('./Label');
 
 SaveAsForm._label = " save as: ";
 function SaveAsForm (opts) {
@@ -15,15 +16,13 @@ function SaveAsForm (opts) {
     field: {left: SaveAsForm._label.length}
   }, Slap.global.options.form.saveAs, opts));
 
-  self.saveAsLabel = new BaseWidget(_.merge({
+  self.saveAsLabel = new Label(_.merge({
     parent: self,
     tags: true,
     content: SaveAsForm._label,
     top: 0,
-    height: 1,
     left: 0,
     width: SaveAsForm._label.length,
-    style: self.options.style
   }, self.options.saveAsLabel));
 
   self.pathField = new Field(_.merge({


### PR DESCRIPTION
While looking at theming options, I noticed that a couple of the forms use labels which are both text boxes - but to style labels you have to style every form, which could get really annoying as more forms are added (e.g. replace).