### PR TITLE
Implement Replace

### DIFF
--- a/lib/ui/FindForm.js
+++ b/lib/ui/FindForm.js
@@ -7,8 +7,10 @@ var BaseWidget = require('base-widget');
 var Slap = require('./Slap');
 var BaseFindForm = require('./BaseFindForm');
 var Label = require('./Label');
+var Field = require('editor-widget').Field;
+var Button = require('./Button');
 
-FindForm._label = " find (/.*/ for regex): ";
+FindForm._label = " Find (/.*/ for regex): ";
 FindForm._regExpRegExp = /^\/(.+)\/(\w*)$/i;
 FindForm._invalidRegExpMessageRegExp = /^(Invalid regular expression:|Invalid flags supplied to RegExp constructor)/;
 function FindForm (opts) {
@@ -17,8 +19,32 @@ function FindForm (opts) {
   if (!(self instanceof FindForm)) return new FindForm(opts);
 
   BaseFindForm.call(self, _.merge({
+    height: 2,
     findField: {left: FindForm._label.length}
   }, Slap.global.options.form.find, opts));
+
+  self.replaceLabel = new Label(_.merge({
+    parent: self,
+    tags: true,
+    content: ' Replace with: ',
+    top: 1,
+    height: 1,
+    left: 0
+  }, self.options.findLabel));
+
+  self.replaceField = new Field(_.merge({
+    parent: self,
+    top: 1,
+    left: 15,
+    right: 9
+  }, Slap.global.options.editor, Slap.global.options.field, self.options.replaceField));
+
+  self.replaceButton = new Button(_.merge({
+    parent: self,
+    content: "Replace",
+    top: 1,
+    right: 0
+  }, Slap.global.options.button, self.options.replaceButton));
 
   self.findLabel = new Label(_.merge({
     parent: self,
@@ -50,7 +76,8 @@ FindForm.prototype._initHandlers = function () {
     editor.destroyMarkers({type: 'findMatch'});
     editor._updateContent();
   });
-  self.on('find', lodash.throttle(function (pattern, direction) {
+
+  var findOrReplace = function (pattern, direction, replacement) {
     direction = direction || 0;
     editor.destroyMarkers({type: 'findMatch'});
     try {
@@ -84,6 +111,9 @@ FindForm.prototype._initHandlers = function () {
       var cmp = matchRange.start.compare(selectionRange.start);
       if (cmp === direction) {
         self.selectRange(matchRange);
+        if (replacement) {
+          editor.textBuf.setTextInRange(editor.selection.getRange(), replacement);
+        }
         return true;
       } else if (!cmp && matches.length === 1) {
         header.message("this is the only occurrence", 'info');
@@ -92,8 +122,17 @@ FindForm.prototype._initHandlers = function () {
     })) {
       header.message("search wrapped", 'info');
       self.selectRange(matches[0].range);
+      if (replacement) {
+        editor.textBuf.setTextInRange(editor.selection.getRange(), replacement);
+      }
     }
     editor._updateContent();
+  };
+
+  self.on('find', lodash.throttle(findOrReplace, self.options.perf.findThrottle));
+
+  self.replaceButton.on('press', lodash.throttle( function () {
+    findOrReplace(self.findField.value(), 0, self.replaceField.value());
   }, self.options.perf.findThrottle));
 
   self.findField.on('keypress', function (ch, key) {

--- a/lib/ui/FindForm.js
+++ b/lib/ui/FindForm.js
@@ -6,6 +6,7 @@ var util = require('slap-util');
 var BaseWidget = require('base-widget');
 var Slap = require('./Slap');
 var BaseFindForm = require('./BaseFindForm');
+var Label = require('./Label');
 
 FindForm._label = " find (/.*/ for regex): ";
 FindForm._regExpRegExp = /^\/(.+)\/(\w*)$/i;
@@ -19,15 +20,13 @@ function FindForm (opts) {
     findField: {left: FindForm._label.length}
   }, Slap.global.options.form.find, opts));
 
-  self.findLabel = new BaseWidget(_.merge({
+  self.findLabel = new Label(_.merge({
     parent: self,
     tags: true,
     content: FindForm._label,
     top: 0,
-    height: 1,
     left: 0,
     width: FindForm._label.length,
-    style: self.options.style
   }, self.options.findLabel));
 }
 FindForm.prototype.__proto__ = BaseFindForm.prototype;

--- a/lib/ui/GoLineForm.js
+++ b/lib/ui/GoLineForm.js
@@ -4,6 +4,7 @@ var BaseWidget = require('base-widget');
 
 var Slap = require('./Slap');
 var BaseFindForm = require('./BaseFindForm');
+var Label = require('./Label');
 
 GoLineForm._label = " line number: ";
 function GoLineForm (opts) {
@@ -15,15 +16,13 @@ function GoLineForm (opts) {
     findField: {left: GoLineForm._label.length}
   }, Slap.global.options.form.goLine, opts));
 
-  self.goLineLabel = new BaseWidget(_.merge({
+  self.goLineLabel = new Label(_.merge({
     parent: self,
     tags: true,
     content: GoLineForm._label,
     top: 0,
-    height: 1,
     left: 0,
     width: GoLineForm._label.length,
-    style: self.options.style
   }, self.options.goLineLabel));
 }
 GoLineForm.prototype.__proto__ = BaseFindForm.prototype;

--- a/lib/ui/Label.js
+++ b/lib/ui/Label.js
@@ -1,0 +1,24 @@
+var blessed = require('blessed');
+var _ = require('lodash');
+
+var util = require('slap-util');
+
+var BaseWidget = require('base-widget');
+var Slap = require('./Slap');
+
+function Label (opts) {
+  var self = this;
+
+  if (!(self instanceof Label)) return new Label(opts);
+
+  opts = _.merge({
+    height: 1
+  }, Slap.global.options.label, opts);
+
+  BaseWidget.blessed.Text.call(self, opts);
+  BaseWidget.call(self, opts);
+}
+
+Label.prototype.__proto__ = BaseWidget.blessed.Text.prototype;
+
+module.exports = Label;

--- a/lib/ui/SaveAsForm.js
+++ b/lib/ui/SaveAsForm.js
@@ -4,6 +4,7 @@ var BaseWidget = require('base-widget');
 var Field = require('editor-widget').Field;
 var Slap = require('./Slap');
 var BaseForm = require('./BaseForm');
+var Label = require('./Label');
 
 SaveAsForm._label = " save as: ";
 function SaveAsForm (opts) {
@@ -15,15 +16,13 @@ function SaveAsForm (opts) {
     field: {left: SaveAsForm._label.length}
   }, Slap.global.options.form.saveAs, opts));
 
-  self.saveAsLabel = new BaseWidget(_.merge({
+  self.saveAsLabel = new Label(_.merge({
     parent: self,
     tags: true,
     content: SaveAsForm._label,
     top: 0,
-    height: 1,
     left: 0,
     width: SaveAsForm._label.length,
-    style: self.options.style
   }, self.options.saveAsLabel));
 
   self.pathField = new Field(_.merge({


### PR DESCRIPTION
This is a simple implementation of a replace feature.
Find continues to work as before, but there is an additional replace line and button. Pressing the button, or hitting enter with the replace line focussed, does a replace.
No attempt is made to perform capture interpolation, e.g. of`$1` (It's not hard, and I have all the necessary bits of code, but different editors have different behaviours so I want to separate out that <s>bikeshedding</s> specification discussion).

One issue I have found is that the tab order is not stable. I don't know if I'm doing something wrong or whether this is a (mis)feature of the way blessed objects are created, where they specify their parents rather than being actively appended to them as you would with a DOM. It is usable, and always possible to tab to all the fields, but sometimes when hitting tab from the find field, you get the replace field, as you'd expect, and other times, you get the Replace button. I'm not able to solve this but I wonder if the react-blessed rewrite will take care of it.

Note that this renders #367 redundant.